### PR TITLE
♻️ refactor: モック認証リポジトリの認証ロジックは gmail.com ではなく例示ドメインを使用するようにした

### DIFF
--- a/lib/infrastructure/mocks/mock_user_repository.dart
+++ b/lib/infrastructure/mocks/mock_user_repository.dart
@@ -12,7 +12,7 @@ class MockUserRepository implements UserRepository {
   @override
   Future<User> signIn({required String email, required String password}) async {
     await Future.delayed(const Duration(seconds: 2));
-    if (email != 'test@gmail.com' || password != 'test') {
+    if (email != 'test@example.com' || password != 'test') {
       throw Exception('メールアドレス または パスワードが異なります');
     }
     return User(


### PR DESCRIPTION
#2