### PR TITLE
usecaseクラスにおける依存関係の表現方法を変更した

### DIFF
--- a/lib/application/usecase/post/post_usecase.dart
+++ b/lib/application/usecase/post/post_usecase.dart
@@ -19,12 +19,14 @@ final postUsecaseProvider = Provider<PostUsecase>(
 /// 投稿ユースケース
 class PostUsecase with RunUsecaseMixin {
   PostUsecase(this._ref);
+
   final Ref _ref;
 
   PostRepository get _postRepository => _ref.read(postRepositoryProvider);
   StorageService get _storageService => _ref.read(storageServiceProvider);
   StateController<bool> get _loadingController =>
       _ref.read(overlayLoadingProvider.notifier);
+  void _invalidatePostsProvider() => _ref.invalidate(postsProvider);
 
   /// 新規投稿をする
   Future<void> addPost({
@@ -52,7 +54,7 @@ class PostUsecase with RunUsecaseMixin {
             ),
           );
         });
-    _ref.invalidate(postsProvider);
+    _invalidatePostsProvider();
   }
 
   /// 投稿の全件取得処理

--- a/lib/application/usecase/post/post_usecase.dart
+++ b/lib/application/usecase/post/post_usecase.dart
@@ -22,6 +22,7 @@ class PostUsecase with RunUsecaseMixin {
 
   final Ref _ref;
 
+  /// 別Providerに依存するものはここに定義して利用する
   PostRepository get _postRepository => _ref.read(postRepositoryProvider);
   StorageService get _storageService => _ref.read(storageServiceProvider);
   StateController<bool> get _loadingController =>

--- a/lib/application/usecase/post/post_usecase.dart
+++ b/lib/application/usecase/post/post_usecase.dart
@@ -9,27 +9,22 @@ import '../../../domain/post/entity/post.dart';
 import '../../../domain/post/post_repository.dart';
 import '../../../domain/user/entity/user.dart';
 import '../run_usecase_mixin.dart';
+import 'state/posts_provider.dart';
 
 /// 投稿ユースケースプロバイダー
 final postUsecaseProvider = Provider<PostUsecase>(
-  (ref) => PostUsecase(
-    postRepository: ref.watch(postRepositoryProvider),
-    storageService: ref.watch(storageServiceProvider),
-    loadingController: ref.watch(overlayLoadingProvider.notifier),
-  ),
+  PostUsecase.new,
 );
 
 /// 投稿ユースケース
 class PostUsecase with RunUsecaseMixin {
-  PostUsecase({
-    required this.postRepository,
-    required this.storageService,
-    required this.loadingController,
-  });
+  PostUsecase(this._ref);
+  final Ref _ref;
 
-  final PostRepository postRepository;
-  final StorageService storageService;
-  final StateController<bool> loadingController;
+  PostRepository get _postRepository => _ref.read(postRepositoryProvider);
+  StorageService get _storageService => _ref.read(storageServiceProvider);
+  StateController<bool> get _loadingController =>
+      _ref.read(overlayLoadingProvider.notifier);
 
   /// 新規投稿をする
   Future<void> addPost({
@@ -44,10 +39,10 @@ class PostUsecase with RunUsecaseMixin {
       throw const AppException();
     }
     await execute(
-        loadingController: loadingController,
+        loadingController: _loadingController,
         action: () async {
-          final imageUrl = await storageService.uploadImage(image: image);
-          await postRepository.add(
+          final imageUrl = await _storageService.uploadImage(image: image);
+          await _postRepository.add(
             post: Post(
               id: null,
               user: user,
@@ -57,6 +52,7 @@ class PostUsecase with RunUsecaseMixin {
             ),
           );
         });
+    _ref.invalidate(postsProvider);
   }
 
   /// 投稿の全件取得処理
@@ -64,7 +60,7 @@ class PostUsecase with RunUsecaseMixin {
   /// 取得後に作成日時が新しい順に並び替える
   Future<List<Post>> fetchAll() async {
     final posts = await execute(action: () async {
-      return await postRepository.fetchAll();
+      return await _postRepository.fetchAll();
     });
 
     final sortedPosts = posts

--- a/lib/application/usecase/user/user_usecase.dart
+++ b/lib/application/usecase/user/user_usecase.dart
@@ -20,6 +20,7 @@ class UserUsecase with RunUsecaseMixin {
 
   final Ref _ref;
 
+  /// 別Providerに依存するものはここに定義して利用する
   UserRepository get _userRepository => _ref.read(userRepositoryProvider);
   StorageService get _storageService => _ref.read(storageServiceProvider);
   CurrentUser get _currentUser => _ref.read(userProvider.notifier);

--- a/lib/application/usecase/user/user_usecase.dart
+++ b/lib/application/usecase/user/user_usecase.dart
@@ -11,30 +11,22 @@ import '../../state/overlay_loading_provider.dart';
 
 /// ユーザーユースケースプロバイダー
 final userUsecaseProvider = Provider<UserUsecase>(
-  (ref) => UserUsecase(
-    userRepository: ref.watch(userRepositoryProvider),
-    storageService: ref.watch(storageServiceProvider),
-    currentUser: ref.watch(userProvider.notifier),
-    loadingController: ref.watch(overlayLoadingProvider.notifier),
-    uidController: ref.watch(uidProvider.notifier),
-  ),
+  UserUsecase.new,
 );
 
 /// ユーザーに関するユースケースを実現するためのクラス
 class UserUsecase with RunUsecaseMixin {
-  UserUsecase({
-    required this.userRepository,
-    required this.storageService,
-    required this.currentUser,
-    required this.loadingController,
-    required this.uidController,
-  });
+  UserUsecase(this._ref);
 
-  final UserRepository userRepository;
-  final StorageService storageService;
-  final CurrentUser currentUser;
-  final StateController<bool> loadingController;
-  final StateController<String?> uidController;
+  final Ref _ref;
+
+  UserRepository get _userRepository => _ref.read(userRepositoryProvider);
+  StorageService get _storageService => _ref.read(storageServiceProvider);
+  CurrentUser get _currentUser => _ref.read(userProvider.notifier);
+  StateController<bool> get _loadingController =>
+      _ref.read(overlayLoadingProvider.notifier);
+  StateController<String?> get _uidController =>
+      _ref.read(uidProvider.notifier);
 
   /// サインアップ
   Future<void> signUp({
@@ -42,13 +34,13 @@ class UserUsecase with RunUsecaseMixin {
     required String password,
   }) async {
     await execute(
-        loadingController: loadingController,
+        loadingController: _loadingController,
         action: () async {
-          final uid = await userRepository.signUp(
+          final uid = await _userRepository.signUp(
             email: email,
             password: password,
           );
-          uidController.state = uid;
+          _uidController.state = uid;
         });
   }
 
@@ -58,14 +50,14 @@ class UserUsecase with RunUsecaseMixin {
     required String password,
   }) async {
     await execute(
-        loadingController: loadingController,
+        loadingController: _loadingController,
         action: () async {
-          final user = await userRepository.signIn(
+          final user = await _userRepository.signIn(
             email: email,
             password: password,
           );
-          uidController.state = user.id;
-          currentUser.set(user);
+          _uidController.state = user.id;
+          _currentUser.set(user);
         });
   }
 
@@ -77,15 +69,15 @@ class UserUsecase with RunUsecaseMixin {
   }) async {
     if (uid == null) return;
     await execute(
-        loadingController: loadingController,
+        loadingController: _loadingController,
         action: () async {
           var imageUrl = '';
           if (image != null) {
-            imageUrl = await storageService.uploadImage(image: image);
+            imageUrl = await _storageService.uploadImage(image: image);
           }
           final user = User(id: uid, userName: userName, imageUrl: imageUrl);
-          final updatedUser = await userRepository.register(user: user);
-          currentUser.set(updatedUser);
+          final updatedUser = await _userRepository.register(user: user);
+          _currentUser.set(updatedUser);
         });
   }
 }

--- a/lib/presentation/page/post/component/post_button.dart
+++ b/lib/presentation/page/post/component/post_button.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_layered_architecture/application/usecase/post/post_usecase.dart';
-import 'package:flutter_layered_architecture/application/usecase/post/state/posts_provider.dart';
 import 'package:flutter_layered_architecture/application/usecase/user/state/user_provider.dart';
-import 'package:flutter_layered_architecture/presentation/presentation_mixin.dart';
 import 'package:flutter_layered_architecture/presentation/page/post/component/post_comment_field.dart';
 import 'package:flutter_layered_architecture/presentation/page/post/component/post_image.dart';
+import 'package:flutter_layered_architecture/presentation/presentation_mixin.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class PostButton extends ConsumerWidget with PresentationMixin {
@@ -25,7 +24,6 @@ class PostButton extends ConsumerWidget with PresentationMixin {
                   user: ref.read(userProvider),
                 );
             navigator.pop();
-            ref.invalidate(postsProvider);
           },
           successMessage: '投稿が完了しました',
         );


### PR DESCRIPTION
## 関連する Issue

- 

@nozomi-koborinai 
こちら先週ちょっと話していた内容に変更しました！

## やったこと

usecaseクラスは完全にDIせずにrefをそのまま渡すようにした

詳細は各コミットメッセージ参照：
- [♻ refactor: post_usecaseにおいてrefを渡す実装に変更](https://github.com/nozomi-koborinai/flutter-layered-architecture/commit/d37f5e456961f444959962d3b89f755451b9e595) 
元々の完全にDIする形だとView側から毎度invalidateをする処理を呼ぶ必要があったが、役責的にはその処理はusecase側に任せたかったので、refを渡す&getterで依存関係を明示する、という運用にした
- [♻ refactor: invalidate経由で別Providerを参照している箇所もプライベートメソッド化した](https://github.com/nozomi-koborinai/flutter-layered-architecture/commit/56e084100064af97531efd5add9878d896460493) 
毎度わざわざここまでするのは大袈裟な気もする
- [♻ refactor: user_usecaseも同様の対応をした](https://github.com/nozomi-koborinai/flutter-layered-architecture/commit/afb135ad477421b728b1e6d41efcd99e5f14d92b)
- [📝 refactor: コメント追記](https://github.com/nozomi-koborinai/flutter-layered-architecture/commit/90f76c49445143c3200233d147503747a4e92f90)


## やらないこと

- 

## スクリーンショット

- 

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点、追加したパッケージなどあれば記載）
